### PR TITLE
Save reference to `rootApp`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,14 @@ var Addon = require('ember-cli/lib/models/addon');
 
 if (!Addon.prototype.import) {
   Addon.prototype.import = function(asset, options) {
-    var app = this.app;
-    while (app.app) {
-      app = app.app;
+    if (!this.rootApp) {
+      var app = this.app;
+      while (app.app) {
+        app = app.app;
+      }
+      this.rootApp = app;
     }
-    app.import(asset, options);
+    this.rootApp.import(asset, options);
   };
 }
 


### PR DESCRIPTION
This allows addons to access properties of the root application, such as `app.test`, without having to process yet another while-loop to unravel the nesting of `app`s.
