### PR TITLE
Exposes the private method to find the host app

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,24 +3,26 @@
 
 var Addon = require('ember-cli/lib/models/addon');
 
-function _findHost(that) {
-  var app = that.app;
-  var parent = that.parent;
-  while (parent.parent) {
-    if (parent.app) {
-      app = parent.app;
-      break;
-    }
-
-    parent = parent.parent;
-  }
-  return app;
-}
-
 if (!Addon.prototype.import) {
   Addon.prototype.import = function(asset, options) {
-    var app = _findHost(this);
+    var app = this._findHost();
     app.import(asset, options);
+  };
+}
+
+if (!Addon.prototype._findHost) {
+  Addon.prototype._findHost = function _findHost() {
+    var app = this.app;
+    var parent = this.parent;
+    while (parent.parent) {
+      if (parent.app) {
+        app = parent.app;
+        break;
+      }
+
+      parent = parent.parent;
+    }
+    return app;
   };
 }
 


### PR DESCRIPTION
This PR exposes `_findHost` as in https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L388.

This is very useful when trying to access `app.bowerDirectory`, which is normally `undefined` from an addon, but `this._findHost().bowerDirectory` returns the proper value.
